### PR TITLE
Add local-user auth mechanism.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ target
 .project
 .classpath
 .settings
+.idea

--- a/src/main/java/org/jboss/sasl/JBossSaslProvider.java
+++ b/src/main/java/org/jboss/sasl/JBossSaslProvider.java
@@ -26,6 +26,7 @@ import static org.jboss.sasl.anonymous.AbstractAnonymousFactory.ANONYMOUS;
 import static org.jboss.sasl.plain.PlainServerFactory.PLAIN;
 import static org.jboss.sasl.digest.DigestMD5ServerFactory.DIGEST_MD5;
 import static org.jboss.sasl.clienttoken.ClientTokenClientFactory.JBOSS_CLIENTTOKEN;
+import static org.jboss.sasl.localuser.LocalUserSaslFactory.JBOSS_LOCAL_USER;
 
 import javax.security.sasl.SaslClientFactory;
 import javax.security.sasl.SaslServerFactory;
@@ -37,6 +38,8 @@ import org.jboss.sasl.clienttoken.ClientTokenClientFactory;
 import org.jboss.sasl.digest.DigestMD5ClientFactory;
 import org.jboss.sasl.digest.DigestMD5ServerFactory;
 import org.jboss.sasl.plain.PlainServerFactory;
+import org.jboss.sasl.localuser.LocalUserClientFactory;
+import org.jboss.sasl.localuser.LocalUserServerFactory;
 
 /**
  * @author <a href="mailto:david.lloyd@redhat.com">David M. Lloyd</a>
@@ -64,7 +67,9 @@ public final class JBossSaslProvider extends Provider {
         put(SASL_SERVER_FACTORY + DOT + PLAIN, PlainServerFactory.class.getName());
         put(SASL_CLIENT_FACTORY + DOT + DIGEST_MD5, DigestMD5ClientFactory.class.getName());
         put(SASL_SERVER_FACTORY + DOT + DIGEST_MD5, DigestMD5ServerFactory.class.getName());
-        //put(SASL_CLIENT_FACTORY + "." + JBOSS_CLIENTTOKEN, ClientTokenClientFactory.class.getName());
+        if (false) put(SASL_CLIENT_FACTORY + "." + JBOSS_CLIENTTOKEN, ClientTokenClientFactory.class.getName());
+        put(SASL_SERVER_FACTORY + DOT + JBOSS_LOCAL_USER, LocalUserServerFactory.class.getName());
+        put(SASL_CLIENT_FACTORY + DOT + JBOSS_LOCAL_USER, LocalUserClientFactory.class.getName());
     }
 
     /**

--- a/src/main/java/org/jboss/sasl/JBossSaslProvider.java
+++ b/src/main/java/org/jboss/sasl/JBossSaslProvider.java
@@ -62,6 +62,7 @@ public final class JBossSaslProvider extends Provider {
      */
     public JBossSaslProvider() {
         super("jboss-sasl", 1.0, INFO);
+        // NOTE: make sure that all client and server factories listed here also end up in the META-INF/services files.
         put(SASL_CLIENT_FACTORY + DOT + ANONYMOUS, AnonymousClientFactory.class.getName());
         put(SASL_SERVER_FACTORY + DOT + ANONYMOUS, AnonymousServerFactory.class.getName());
         put(SASL_SERVER_FACTORY + DOT + PLAIN, PlainServerFactory.class.getName());

--- a/src/main/java/org/jboss/sasl/localuser/LocalUserClient.java
+++ b/src/main/java/org/jboss/sasl/localuser/LocalUserClient.java
@@ -1,0 +1,95 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2011, Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+
+package org.jboss.sasl.localuser;
+
+import java.io.File;
+import java.io.FileInputStream;
+import java.io.IOException;
+import org.jboss.sasl.util.AbstractSaslClient;
+import org.jboss.sasl.util.Charsets;
+import org.jboss.sasl.util.SaslState;
+import org.jboss.sasl.util.SaslStateContext;
+
+import javax.security.auth.callback.CallbackHandler;
+import javax.security.auth.callback.NameCallback;
+import javax.security.sasl.RealmCallback;
+import javax.security.sasl.SaslException;
+
+/**
+ * @author <a href="mailto:david.lloyd@redhat.com">David M. Lloyd</a>
+ */
+public final class LocalUserClient extends AbstractSaslClient {
+
+    LocalUserClient(final String protocol, final String serverName, final CallbackHandler callbackHandler, final String authorizationId) {
+        super(LocalUserSaslFactory.JBOSS_LOCAL_USER, protocol, serverName, callbackHandler, authorizationId, true);
+    }
+
+    public void init() {
+        getContext().setNegotiationState(new SaslState() {
+            public byte[] evaluateMessage(final SaslStateContext context, final byte[] message) throws SaslException {
+                final String authorizationId = getAuthorizationId();
+                final byte[] bytes = new byte[Charsets.encodedLengthOf(authorizationId)];
+                Charsets.encodeTo(authorizationId, bytes, 0);
+                context.setNegotiationState(new SaslState() {
+                    public byte[] evaluateMessage(final SaslStateContext context, final byte[] message) throws SaslException {
+                        final String path = new String(message, Charsets.UTF_8);
+                        final File file = new File(path);
+                        final byte[] challenge = new byte[8];
+                        int t = 0;
+                        try {
+                            final FileInputStream stream = new FileInputStream(file);
+                            while (t < 8) {
+                                int r = stream.read(challenge, t, 8-t);
+                                if (r < 0) {
+                                    throw new SaslException("Invalid server challenge");
+                                } else {
+                                    t += r;
+                                }
+                            }
+                        } catch (IOException e) {
+                            throw new SaslException("Failed to read server challenge", e);
+                        }
+                        String authenticationId = getAuthorizationId();
+                        String authenticationRealm;
+                        final NameCallback nameCallback = new NameCallback("User name", authenticationId);
+                        final RealmCallback realmCallback = new RealmCallback("User realm");
+                        handleCallbacks(nameCallback, realmCallback);
+                        authenticationId = nameCallback.getName();
+                        authenticationRealm = realmCallback.getText();
+                        if (authenticationId == null) authenticationId = "";
+                        if (authenticationRealm == null) authenticationRealm = "";
+                        final int authenticationIdLength = Charsets.encodedLengthOf(authenticationId);
+                        final int authenticationRealmLength = Charsets.encodedLengthOf(authenticationRealm);
+                        final byte[] response = new byte[8 + 1 + authenticationIdLength + authenticationRealmLength];
+                        System.arraycopy(challenge, 0, response, 0, 8);
+                        Charsets.encodeTo(authenticationId, response, 8);
+                        Charsets.encodeTo(authenticationRealm, response, 8 + 1 + authenticationIdLength);
+                        context.negotiationComplete();
+                        return response;
+                    }
+                });
+                return bytes;
+            }
+        });
+    }
+}

--- a/src/main/java/org/jboss/sasl/localuser/LocalUserClientFactory.java
+++ b/src/main/java/org/jboss/sasl/localuser/LocalUserClientFactory.java
@@ -1,0 +1,45 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2011, Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+
+package org.jboss.sasl.localuser;
+
+import java.util.Map;
+
+import javax.security.auth.callback.CallbackHandler;
+import javax.security.sasl.SaslClient;
+import javax.security.sasl.SaslClientFactory;
+import javax.security.sasl.SaslException;
+
+/**
+ * @author <a href="mailto:david.lloyd@redhat.com">David M. Lloyd</a>
+ */
+public final class LocalUserClientFactory extends LocalUserSaslFactory implements SaslClientFactory {
+
+    public SaslClient createSaslClient(final String[] mechanisms, final String authorizationId, final String protocol, final String serverName, final Map<String, ?> props, final CallbackHandler cbh) throws SaslException {
+        if (! isIncluded(mechanisms)) {
+            return null;
+        }
+        final LocalUserClient client = new LocalUserClient(protocol, serverName, cbh, authorizationId);
+        client.init();
+        return client;
+    }
+}

--- a/src/main/java/org/jboss/sasl/localuser/LocalUserSaslFactory.java
+++ b/src/main/java/org/jboss/sasl/localuser/LocalUserSaslFactory.java
@@ -1,0 +1,63 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2011, Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+
+package org.jboss.sasl.localuser;
+
+import org.jboss.sasl.util.AbstractSaslFactory;
+
+/**
+ * Base class for the {@code JBOSS-LOCAL-USER} SASL mechanism.
+ *
+ * @author <a href="mailto:david.lloyd@redhat.com">David M. Lloyd</a>
+ */
+public abstract class LocalUserSaslFactory extends AbstractSaslFactory {
+
+    public static final String JBOSS_LOCAL_USER = "JBOSS-LOCAL-USER";
+
+    LocalUserSaslFactory() {
+        super(JBOSS_LOCAL_USER);
+    }
+
+    protected boolean isPassCredentials() {
+        return false;
+    }
+
+    protected boolean isDictionarySusceptible() {
+        return false;
+    }
+
+    protected boolean isActiveSusceptible() {
+        return false;
+    }
+
+    protected boolean isForwardSecrecy() {
+        return false;
+    }
+
+    protected boolean isPlainText() {
+        return true;
+    }
+
+    protected boolean isAnonymous() {
+        return false;
+    }
+}

--- a/src/main/java/org/jboss/sasl/localuser/LocalUserServer.java
+++ b/src/main/java/org/jboss/sasl/localuser/LocalUserServer.java
@@ -81,6 +81,10 @@ public final class LocalUserServer extends AbstractSaslServer implements SaslSer
     public void init() {
         getContext().setNegotiationState(new SaslState() {
             public byte[] evaluateMessage(final SaslStateContext context, final byte[] message) throws SaslException {
+                if (message.length == 0) {
+                    // trigger initial response
+                    return NO_BYTES;
+                }
                 // initial message
                 authorizationId = message.length > 0 ? new String(message, Charsets.UTF_8) : null;
                 final Random random = new Random();

--- a/src/main/java/org/jboss/sasl/localuser/LocalUserServer.java
+++ b/src/main/java/org/jboss/sasl/localuser/LocalUserServer.java
@@ -1,0 +1,175 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2011, Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+
+package org.jboss.sasl.localuser;
+
+import java.io.File;
+import java.io.FileNotFoundException;
+import java.io.FileOutputStream;
+import java.io.IOException;
+import java.security.AccessController;
+import java.security.PrivilegedAction;
+import java.util.Arrays;
+import java.util.Map;
+import java.util.Random;
+import org.jboss.sasl.util.AbstractSaslServer;
+import org.jboss.sasl.util.Charsets;
+import org.jboss.sasl.util.SaslState;
+import org.jboss.sasl.util.SaslStateContext;
+
+import javax.security.auth.callback.CallbackHandler;
+import javax.security.auth.callback.NameCallback;
+import javax.security.sasl.AuthorizeCallback;
+import javax.security.sasl.RealmCallback;
+import javax.security.sasl.SaslException;
+import javax.security.sasl.SaslServer;
+
+/**
+ * @author <a href="mailto:david.lloyd@redhat.com">David M. Lloyd</a>
+ */
+public final class LocalUserServer extends AbstractSaslServer implements SaslServer {
+
+    public static final String LOCAL_USER_CHALLENGE_PATH = "jboss.sasl.local-user.challenge-path";
+
+    private volatile String authorizationId;
+    private final File basePath;
+
+    LocalUserServer(final String protocol, final String serverName, final Map<String, ?> props, final CallbackHandler callbackHandler) {
+        super(LocalUserSaslFactory.JBOSS_LOCAL_USER, protocol, serverName, callbackHandler);
+        String value;
+        if (props.containsKey(LOCAL_USER_CHALLENGE_PATH)) {
+            basePath = new File(props.get(LOCAL_USER_CHALLENGE_PATH).toString()).getAbsoluteFile();
+        } else if ((value = getProperty(LOCAL_USER_CHALLENGE_PATH)) != null) {
+            basePath = new File(value).getAbsoluteFile();
+        } else {
+            basePath = new File(getProperty("java.io.tmpdir"));
+        }
+    }
+
+    private static String getProperty(final String name) {
+        final SecurityManager sm = System.getSecurityManager();
+        if (sm != null) {
+            return AccessController.doPrivileged(new PrivilegedAction<String>() {
+                public String run() {
+                    return System.getProperty(name);
+                }
+            });
+        } else {
+            return System.getProperty(name);
+        }
+    }
+
+    public void init() {
+        getContext().setNegotiationState(new SaslState() {
+            public byte[] evaluateMessage(final SaslStateContext context, final byte[] message) throws SaslException {
+                // initial message
+                authorizationId = message.length > 0 ? new String(message, Charsets.UTF_8) : null;
+                final Random random = new Random();
+                File testFile;
+                do {
+                    testFile = new File(basePath, "challenge-" + (random.nextInt(8999999) + 1000000));
+                } while (testFile.exists());
+                final File challengeFile = testFile;
+                final FileOutputStream fos;
+                try {
+                    challengeFile.delete();
+                    fos = new FileOutputStream(testFile);
+                    challengeFile.deleteOnExit();
+                } catch (FileNotFoundException e) {
+                    throw new SaslException("Failed to create challenge file", e);
+                }
+                boolean ok = false;
+                final byte[] bytes;
+                try {
+                    bytes = new byte[8];
+                    random.nextBytes(bytes);
+                    try {
+                        fos.write(bytes);
+                        fos.close();
+                        ok = true;
+                    } catch (IOException e) {
+                        throw new SaslException("Failed to create challenge file", e);
+                    }
+                } finally {
+                    if (!ok) {
+                        challengeFile.delete();
+                    }
+                    try {
+                        fos.close();
+                    } catch (Throwable ignored) {
+                    }
+                }
+                final String path = challengeFile.getAbsolutePath();
+                final byte[] response = new byte[Charsets.encodedLengthOf(path)];
+                Charsets.encodeTo(path, response, 0);
+                getContext().setNegotiationState(new SaslState() {
+                    public byte[] evaluateMessage(final SaslStateContext context, final byte[] message) throws SaslException {
+                        challengeFile.delete();
+                        final int length = message.length;
+                        if (length < 8) {
+                            throw new SaslException("Invalid response");
+                        }
+                        if (!Arrays.equals(bytes, Arrays.copyOf(message, 8))) {
+                            throw new SaslException("Invalid response");
+                        }
+                        String authenticationRealm;
+                        String authenticationId;
+                        final int firstMarker = Charsets.indexOf(message, 0, 8);
+                        if (firstMarker > -1) {
+                            authenticationId = new String(message, 8, firstMarker - 8, Charsets.UTF_8);
+                            final int secondMarker = Charsets.indexOf(message, 0, firstMarker + 1);
+                            if (secondMarker > -1) {
+                                authenticationRealm = new String(message, firstMarker + 1, secondMarker - firstMarker - 1, Charsets.UTF_8);
+                            } else {
+                                authenticationRealm = null;
+                            }
+                        } else {
+                            authenticationId = null;
+                            authenticationRealm = null;
+                        }
+                        if (authenticationId == null) {
+                            throw new SaslException("No authentication ID given");
+                        }
+                        final NameCallback nameCallback = new NameCallback("User name", authenticationId);
+                        final AuthorizeCallback authorizeCallback = new AuthorizeCallback(authenticationId, authorizationId);
+                        if (authenticationRealm == null) {
+                            handleCallbacks(nameCallback, authorizeCallback);
+                        } else {
+                            final RealmCallback realmCallback = new RealmCallback("User realm", authenticationRealm);
+                            handleCallbacks(realmCallback, nameCallback, authorizeCallback);
+                        }
+                        if (!authorizeCallback.isAuthorized()) {
+                            throw new SaslException("User " + authorizationId + " is not authorized");
+                        }
+                        context.negotiationComplete();
+                        return null;
+                    }
+                });
+                return response;
+            }
+        });
+    }
+
+    public String getAuthorizationID() {
+        return authorizationId;
+    }
+}

--- a/src/main/java/org/jboss/sasl/localuser/LocalUserServerFactory.java
+++ b/src/main/java/org/jboss/sasl/localuser/LocalUserServerFactory.java
@@ -1,0 +1,45 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2011, Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+
+package org.jboss.sasl.localuser;
+
+import java.util.Map;
+
+import javax.security.auth.callback.CallbackHandler;
+import javax.security.sasl.SaslException;
+import javax.security.sasl.SaslServer;
+import javax.security.sasl.SaslServerFactory;
+
+/**
+ * @author <a href="mailto:david.lloyd@redhat.com">David M. Lloyd</a>
+ */
+public class LocalUserServerFactory extends LocalUserSaslFactory implements SaslServerFactory {
+
+    public SaslServer createSaslServer(final String mechanism, final String protocol, final String serverName, final Map<String, ?> props, final CallbackHandler cbh) throws SaslException {
+        if (! isIncluded(mechanism)) {
+            return null;
+        }
+        final LocalUserServer server = new LocalUserServer(protocol, serverName, props, cbh);
+        server.init();
+        return server;
+    }
+}

--- a/src/main/java/org/jboss/sasl/util/AbstractSaslParticipant.java
+++ b/src/main/java/org/jboss/sasl/util/AbstractSaslParticipant.java
@@ -100,11 +100,12 @@ public abstract class AbstractSaslParticipant {
             callbackHandler.handle(callbacks);
         } catch (SaslException e) {
             throw e;
-        } catch (IOException e) {
-            throw new SaslException("Callback handler invocation failed", e);
+        } catch (Throwable t) {
+            throw new SaslException("Callback handler invocation failed", t);
         }
     }
 
+    public void init() {};
 
     /**
      * Get the name of this mechanism.

--- a/src/main/java/org/jboss/sasl/util/Charsets.java
+++ b/src/main/java/org/jboss/sasl/util/Charsets.java
@@ -39,7 +39,132 @@ public final class Charsets {
     /**
      * The {@code 8859_1} character set.
      */
-    public static final Charset EIGHT859_1 = Charset.forName("8859_1");
+    public static final Charset LATIN_1 = Charset.forName("8859_1");
+
+    /**
+     * Encode a string into UTF-8 (except encoding character zero to its two-byte form).
+     *
+     * @param src the source string
+     * @param dest the array to encode to
+     * @param offs the offset into the destination array
+     * @return {@code true} if the string fit, {@code false} if it did not
+     */
+    public static boolean encodeTo(String src, byte[] dest, int offs) {
+        final int srcLen = src.length();
+        try {
+            for (int i = 0; i < srcLen; i = src.offsetByCodePoints(i, 1)) {
+                int cp = src.codePointAt(i);
+                if (cp > 0 && cp <= 0x7f) {
+                    // don't accidentally null-terminate the string
+                    dest[offs ++] = (byte) cp;
+                } else if (cp <= 0x07ff) {
+                    dest[offs ++] = (byte)(0xc0 | 0x1f & cp >> 6);
+                    dest[offs ++] = (byte)(0x80 | 0x3f & cp);
+                } else if (cp <= 0xffff) {
+                    dest[offs ++] = (byte)(0xe0 | 0x0f & cp >> 12);
+                    dest[offs ++] = (byte)(0x80 | 0x3f & cp >> 6);
+                    dest[offs ++] = (byte)(0x80 | 0x3f & cp);
+                } else if (cp <= 0x1fffff) {
+                    dest[offs ++] = (byte)(0xf0 | 0x07 & cp >> 18);
+                    dest[offs ++] = (byte)(0x80 | 0x3f & cp >> 12);
+                    dest[offs ++] = (byte)(0x80 | 0x3f & cp >> 6);
+                    dest[offs ++] = (byte)(0x80 | 0x3f & cp);
+                } else if (cp <= 0x3ffffff) {
+                    dest[offs ++] = (byte)(0xf8 | 0x03 & cp >> 24);
+                    dest[offs ++] = (byte)(0x80 | 0x3f & cp >> 18);
+                    dest[offs ++] = (byte)(0x80 | 0x3f & cp >> 12);
+                    dest[offs ++] = (byte)(0x80 | 0x3f & cp >> 6);
+                    dest[offs ++] = (byte)(0x80 | 0x3f & cp);
+                } else if (cp >= 0) {
+                    dest[offs ++] = (byte)(0xfc | 0x01 & cp >> 30);
+                    dest[offs ++] = (byte)(0x80 | 0x3f & cp >> 24);
+                    dest[offs ++] = (byte)(0x80 | 0x3f & cp >> 18);
+                    dest[offs ++] = (byte)(0x80 | 0x3f & cp >> 12);
+                    dest[offs ++] = (byte)(0x80 | 0x3f & cp >> 6);
+                    dest[offs ++] = (byte)(0x80 | 0x3f & cp);
+                } else {
+                    // replacement char
+                    dest[offs ++] = '?';
+                }
+            }
+            return true;
+        } catch (ArrayIndexOutOfBoundsException e) {
+            return false;
+        }
+    }
+
+    /**
+     * Get the encoded length of a string.
+     *
+     * @param src the string
+     * @return its encoded length
+     */
+    public static int encodedLengthOf(String src) {
+        final int srcLen = src.length();
+        int l = 0;
+        for (int i = 0; i < srcLen; i = src.offsetByCodePoints(i, 1)) {
+            int cp = src.codePointAt(i);
+            if (cp > 0 && cp <= 0x7f) {
+                // don't accidentally null-terminate the string
+                l ++;
+            } else if (cp <= 0x07ff) {
+                l += 2;
+            } else if (cp <= 0xffff) {
+                l += 3;
+            } else if (cp <= 0x1fffff) {
+                l += 4;
+            } else if (cp <= 0x3ffffff) {
+                l += 5;
+            } else if (cp >= 0) {
+                l += 6;
+            } else {
+                // replacement char
+                l ++;
+            }
+        }
+        return l;
+    }
+
+    /**
+     * Find the first occurrence of a byte in a byte array.
+     *
+     * @param array the array to search
+     * @param search the byte to search for
+     * @param offs the offset in the array to start searching
+     * @param len the length of the segment to search
+     * @return the index, or -1 if the byte is not found
+     */
+    public static int indexOf(byte[] array, int search, int offs, int len) {
+        for (int i = 0; i < len; i ++) {
+            if (array[offs + i] == (byte) search) {
+                return offs + i;
+            }
+        }
+        return -1;
+    }
+
+    /**
+     * Find the first occurrence of a byte in a byte array.
+     *
+     * @param array the array to search
+     * @param search the byte to search for
+     * @param offs the offset in the array to start searching
+     * @return the index, or -1 if the byte is not found
+     */
+    public static int indexOf(byte[] array, int search, int offs) {
+        return indexOf(array, search, offs, array.length - offs);
+    }
+
+    /**
+     * Find the first occurrence of a byte in a byte array.
+     *
+     * @param array the array to search
+     * @param search the byte to search for
+     * @return the index, or -1 if the byte is not found
+     */
+    public static int indexOf(byte[] array, int search) {
+        return indexOf(array, search, 0, array.length);
+    }
 
     private Charsets() {
     }

--- a/src/main/java/org/jboss/sasl/util/UsernamePasswordHashUtil.java
+++ b/src/main/java/org/jboss/sasl/util/UsernamePasswordHashUtil.java
@@ -21,7 +21,7 @@
  */
 package org.jboss.sasl.util;
 
-import static org.jboss.sasl.util.Charsets.EIGHT859_1;
+import static org.jboss.sasl.util.Charsets.LATIN_1;
 import static org.jboss.sasl.util.Charsets.UTF_8;
 
 import java.io.ByteArrayOutputStream;
@@ -92,7 +92,7 @@ public class UsernamePasswordHashUtil {
             }
         }
 
-        return toConvert.getBytes(EIGHT859_1);
+        return toConvert.getBytes(LATIN_1);
     }
 
     /**
@@ -113,7 +113,7 @@ public class UsernamePasswordHashUtil {
             }
         }
 
-        return String.valueOf(toConvert).getBytes(EIGHT859_1);
+        return String.valueOf(toConvert).getBytes(LATIN_1);
     }
 
     /**

--- a/src/main/resources/META-INF/services/javax.security.sasl.SaslClientFactory
+++ b/src/main/resources/META-INF/services/javax.security.sasl.SaslClientFactory
@@ -1,0 +1,27 @@
+#
+# JBoss, Home of Professional Open Source.
+# Copyright 2011, Red Hat, Inc., and individual contributors
+# as indicated by the @author tags. See the copyright.txt file in the
+# distribution for a full listing of individual contributors.
+#
+# This is free software; you can redistribute it and/or modify it
+# under the terms of the GNU Lesser General Public License as
+# published by the Free Software Foundation; either version 2.1 of
+# the License, or (at your option) any later version.
+#
+# This software is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+# Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public
+# License along with this software; if not, write to the Free
+# Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+# 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+#
+
+# our SASL factory providers
+org.jboss.sasl.anonymous.AnonymousClientFactory
+org.jboss.sasl.digest.DigestMD5ClientFactory
+org.jboss.sasl.clienttoken.ClientTokenClientFactory
+org.jboss.sasl.localuser.LocalUserClientFactory

--- a/src/main/resources/META-INF/services/javax.security.sasl.SaslServerFactory
+++ b/src/main/resources/META-INF/services/javax.security.sasl.SaslServerFactory
@@ -1,0 +1,27 @@
+#
+# JBoss, Home of Professional Open Source.
+# Copyright 2011, Red Hat, Inc., and individual contributors
+# as indicated by the @author tags. See the copyright.txt file in the
+# distribution for a full listing of individual contributors.
+#
+# This is free software; you can redistribute it and/or modify it
+# under the terms of the GNU Lesser General Public License as
+# published by the Free Software Foundation; either version 2.1 of
+# the License, or (at your option) any later version.
+#
+# This software is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+# Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public
+# License along with this software; if not, write to the Free
+# Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+# 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+#
+
+# our SASL factory providers
+org.jboss.sasl.anonymous.AnonymousServerFactory
+org.jboss.sasl.plain.PlainServerFactory
+org.jboss.sasl.digest.DigestMD5ServerFactory
+org.jboss.sasl.localuser.LocalUserServerFactory

--- a/src/test/java/org/jboss/sasl/test/LocalUserTest.java
+++ b/src/test/java/org/jboss/sasl/test/LocalUserTest.java
@@ -1,0 +1,73 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2011, Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+
+package org.jboss.sasl.test;
+
+import java.util.Collections;
+import org.junit.Test;
+
+import javax.security.auth.callback.CallbackHandler;
+import javax.security.sasl.Sasl;
+import javax.security.sasl.SaslClient;
+import javax.security.sasl.SaslServer;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
+
+/**
+ * Test for the local user SASL mechanism, this will test both the client and server side.
+ *
+ * @author <a href="mailto:darran.lofthouse@jboss.com">Darran Lofthouse</a>
+ * @author <a href="mailto:david.lloyd@redhat.com">David M. Lloyd</a>
+ */
+public class LocalUserTest extends BaseTestCase {
+
+    private static final String LOCAL_USER = "JBOSS-LOCAL-USER";
+    /*
+     *  Normal SASL Client/Server interaction.
+     */
+
+    /**
+     * Test a successful exchange using the ANONYMOUS mechanism.
+     */
+
+    @Test
+    public void testSuccessfulExchange() throws Exception {
+        CallbackHandler serverCallback = new ServerCallbackHandler("George", (char[]) null);
+        SaslServer server = Sasl.createSaslServer(LOCAL_USER, "TestProtocol", "TestServer", Collections.<String, Object>emptyMap(), serverCallback);
+
+        CallbackHandler clientCallback = new ClientCallbackHandler("George", (char[]) null);
+        SaslClient client = Sasl.createSaslClient(new String[]{ LOCAL_USER }, "George", "TestProtocol", "TestServer", Collections.<String, Object>emptyMap(), clientCallback);
+
+        assertTrue(client.hasInitialResponse());
+        byte[] response = client.evaluateChallenge(new byte[0]);
+        byte[] challenge = server.evaluateResponse(response);
+        response = client.evaluateChallenge(challenge);
+        challenge = server.evaluateResponse(response);
+        assertNull(challenge);
+        assertTrue(server.isComplete());
+        assertTrue(client.isComplete());
+        assertEquals("George", server.getAuthorizationID());
+    }
+
+}


### PR DESCRIPTION
Adds some encoding stuff too.  Configure the challenge file path with the "jboss.sasl.local-user.challenge-path" mechanism property or system property.  If not configured, uses java.io.tmpdir (on well-configured systems, users can only read their own temp files).
