### PR TITLE
SASL-41 Make JBoss SASL an OSGi bundle

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -30,6 +30,7 @@
     <groupId>org.jboss.sasl</groupId>
     <artifactId>jboss-sasl</artifactId>
     <version>1.0.4.CR1-SNAPSHOT</version>
+    <packaging>bundle</packaging>
 
     <parent>
         <groupId>org.jboss</groupId>
@@ -80,6 +81,31 @@
                             </targetMembers>
                         </bytecodeInjection>
                     </bytecodeInjections>
+                </configuration>
+            </plugin>
+            
+            <!-- provides bundle packaging -->
+            <plugin>
+                <groupId>org.apache.felix</groupId>
+                <artifactId>maven-bundle-plugin</artifactId>
+                <version>2.3.7</version>
+                <extensions>true</extensions>
+                <configuration>
+                    <archive>
+                      <index>true</index>
+                    </archive>
+                    <instructions>
+                        <Import-Package>
+                          *
+                        </Import-Package>
+                        <Export-Package>
+                          ${project.groupId}.*;version=${project.version}
+                        </Export-Package>
+                        <Bundle-ActivationPolicy>lazy</Bundle-ActivationPolicy>
+                        <Include-Resource>
+                          {maven-resources}
+                        </Include-Resource>
+                    </instructions>
                 </configuration>
             </plugin>
         </plugins>


### PR DESCRIPTION
We'd like to deploy JBoss SASL in an OSGi environment (Equinox). For
this is would be convenient for us if JBoss SASL was already an OSGi
bundle and we don't have to wrap it.

https://issues.jboss.org/browse/SASL-41
